### PR TITLE
fix(bridge): critical fixes and enhancements (5 fixes)

### DIFF
--- a/cmd/ysf-nexus/main.go
+++ b/cmd/ysf-nexus/main.go
@@ -88,7 +88,7 @@ func runServer(cmd *cobra.Command, args []string) error {
 		logger.String("config_file", configFile))
 
 	// Create and start reflector
-	r := reflector.New(cfg, log)
+	r := reflector.NewWithVersion(cfg, log, Version, BuildTime)
 
 	// Setup context for graceful shutdown
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/bridge/bridge.go
+++ b/pkg/bridge/bridge.go
@@ -239,9 +239,9 @@ func (b *Bridge) disconnect() {
 	if b.state == StateConnected {
 		b.logger.Info("Disconnecting bridge")
 
-		// Send disconnect packet
+		// Send disconnect packet using sendDisconnectLocked to avoid double-lock
 		if b.remoteAddr != nil {
-			if err := b.sendDisconnect(); err != nil {
+			if err := b.sendDisconnectLocked(); err != nil {
 				b.logger.Warn("Failed to send disconnect packet", logger.Error(err))
 			}
 		}
@@ -380,6 +380,12 @@ func (b *Bridge) sendDisconnect() error {
 	// Create YSF disconnect packet
 	disconnect := b.createDisconnectPacket()
 	return b.sendPacket(disconnect)
+}
+
+func (b *Bridge) sendDisconnectLocked() error {
+	// Create YSF disconnect packet
+	disconnect := b.createDisconnectPacket()
+	return b.sendPacketLocked(disconnect)
 }
 
 func (b *Bridge) sendPacket(data []byte) error {

--- a/pkg/bridge/bridge.go
+++ b/pkg/bridge/bridge.go
@@ -449,8 +449,20 @@ func (b *Bridge) createPingPacket() []byte {
 }
 
 func (b *Bridge) createDisconnectPacket() []byte {
-	// TODO: Implement YSF-specific disconnect packet
-	return []byte("YSFD")
+	// Create YSFU (YSF Unlink) packet - 14 bytes total
+	packet := make([]byte, 14)
+
+	// Packet type: YSFU
+	copy(packet[0:4], "YSFU")
+
+	// Callsign (padded to 10 bytes with spaces)
+	callsign := b.config.Name
+	if len(callsign) > 10 {
+		callsign = callsign[:10]
+	}
+	copy(packet[4:14], fmt.Sprintf("%-10s", callsign))
+
+	return packet
 }
 
 // Status and utility methods

--- a/pkg/bridge/bridge_test.go
+++ b/pkg/bridge/bridge_test.go
@@ -38,6 +38,7 @@ func TestBridgeManager_PermanentBridge(t *testing.T) {
 			Name:       "test-permanent",
 			Host:       "localhost",
 			Port:       4200,
+			Enabled:    true,
 			Permanent:  true,
 			MaxRetries: 3,
 			RetryDelay: 1 * time.Second,
@@ -85,6 +86,7 @@ func TestBridgeManager_ScheduledBridge(t *testing.T) {
 			Name:     "test-scheduled",
 			Host:     "localhost",
 			Port:     4200,
+			Enabled:  true,
 			Schedule: "* * * * * *", // Every second
 			Duration: 2 * time.Second,
 		},

--- a/pkg/bridge/manager.go
+++ b/pkg/bridge/manager.go
@@ -101,6 +101,12 @@ func (m *Manager) Start() error {
 	m.logger.Info("Starting bridge manager")
 
 	for _, bridgeConfig := range m.config {
+		// Skip disabled bridges
+		if !bridgeConfig.Enabled {
+			m.logger.Info("Skipping disabled bridge", logger.String("name", bridgeConfig.Name))
+			continue
+		}
+
 		if err := m.setupBridge(bridgeConfig); err != nil {
 			m.logger.Error("Failed to setup bridge",
 				logger.String("name", bridgeConfig.Name),

--- a/pkg/network/packets_sanitize_test.go
+++ b/pkg/network/packets_sanitize_test.go
@@ -1,0 +1,125 @@
+package network
+
+import (
+	"testing"
+)
+
+func TestSanitizeCallsign(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "dash suffix",
+			input:    "KF8S-DAVE",
+			expected: "KF8S",
+		},
+		{
+			name:     "slash suffix",
+			input:    "N8ZA/CHUCK",
+			expected: "N8ZA",
+		},
+		{
+			name:     "space suffix",
+			input:    "M0FXB AND",
+			expected: "M0FXB",
+		},
+		{
+			name:     "no suffix",
+			input:    "W1ABC",
+			expected: "W1ABC",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "with leading/trailing spaces",
+			input:    "  KB1TEST  ",
+			expected: "KB1TEST",
+		},
+		{
+			name:     "multiple delimiters",
+			input:    "W2XYZ-RPT/B",
+			expected: "W2XYZ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SanitizeCallsign(tt.input)
+			if result != tt.expected {
+				t.Errorf("SanitizeCallsign(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSanitizeDataPacket(t *testing.T) {
+	// Create a test YSFD packet
+	packet := make([]byte, DataPacketSize)
+	copy(packet[0:4], "YSFD")
+
+	// Set gateway callsign (bytes 4-14): "KF8S-DAVE "
+	copy(packet[4:14], "KF8S-DAVE ")
+
+	// Set source callsign (bytes 14-24): "N8ZA/CHUCK"
+	copy(packet[14:24], "N8ZA/CHUCK")
+
+	// Set destination callsign (bytes 24-34): "M0FXB AND "
+	copy(packet[24:34], "M0FXB AND ")
+
+	// Sanitize the packet
+	sanitized := SanitizeDataPacket(packet)
+
+	// Verify gateway callsign was cleaned (should be "KF8S      ")
+	gatewayCS := string(sanitized[4:14])
+	if gatewayCS[:4] != "KF8S" {
+		t.Errorf("Gateway callsign not sanitized correctly: got %q, want 'KF8S      '", gatewayCS)
+	}
+
+	// Verify source callsign was cleaned (should be "N8ZA      ")
+	sourceCS := string(sanitized[14:24])
+	if sourceCS[:4] != "N8ZA" {
+		t.Errorf("Source callsign not sanitized correctly: got %q, want 'N8ZA      '", sourceCS)
+	}
+
+	// Verify destination callsign was cleaned (should be "M0FXB     ")
+	destCS := string(sanitized[24:34])
+	if destCS[:5] != "M0FXB" {
+		t.Errorf("Destination callsign not sanitized correctly: got %q, want 'M0FXB     '", destCS)
+	}
+
+	// Verify original packet was not modified
+	if string(packet[4:14]) != "KF8S-DAVE " {
+		t.Error("Original packet was modified")
+	}
+}
+
+func TestSanitizeDataPacket_NonDataPacket(t *testing.T) {
+	// Create a YSFP packet (not data)
+	packet := make([]byte, PollPacketSize)
+	copy(packet[0:4], "YSFP")
+	copy(packet[4:14], "TEST-CS   ")
+
+	// Sanitize should return unchanged for non-data packets
+	sanitized := SanitizeDataPacket(packet)
+
+	if string(sanitized[4:14]) != "TEST-CS   " {
+		t.Error("Non-data packet was modified when it shouldn't be")
+	}
+}
+
+func TestSanitizeDataPacket_TooSmall(t *testing.T) {
+	// Create a packet that's too small
+	packet := []byte{0x59, 0x53, 0x46}
+
+	// Should return unchanged
+	sanitized := SanitizeDataPacket(packet)
+
+	if len(sanitized) != len(packet) {
+		t.Error("Packet size changed for too-small packet")
+	}
+}

--- a/pkg/reflector/reflector.go
+++ b/pkg/reflector/reflector.go
@@ -51,7 +51,9 @@ type Reflector struct {
 	eventChan       chan repeater.Event
 	running         bool
 	mu              sync.RWMutex
-	
+	version         string
+	buildTime       string
+
 	// Bridge talker tracking
 	bridgeTalkers   map[string]*bridgeTalker // key: callsign+bridge_name
 	talkersMu       sync.RWMutex
@@ -59,6 +61,11 @@ type Reflector struct {
 
 // New creates a new YSF reflector
 func New(cfg *config.Config, log *logger.Logger) *Reflector {
+	return NewWithVersion(cfg, log, "dev", "unknown")
+}
+
+// NewWithVersion creates a new YSF reflector with version information
+func NewWithVersion(cfg *config.Config, log *logger.Logger, version, buildTime string) *Reflector {
 	eventChan := make(chan repeater.Event, 1000)
 
 	r := &Reflector{
@@ -66,6 +73,8 @@ func New(cfg *config.Config, log *logger.Logger) *Reflector {
 		logger:        log.WithComponent("reflector"),
 		eventChan:     eventChan,
 		bridgeTalkers: make(map[string]*bridgeTalker),
+		version:       version,
+		buildTime:     buildTime,
 	}
 
 	// Initialize network server
@@ -86,7 +95,7 @@ func New(cfg *config.Config, log *logger.Logger) *Reflector {
 	r.bridgeManager = bridge.NewManager(cfg.Bridges, r.server, r.logger)
 
 	// Initialize web server
-	r.webServer = web.NewServer(cfg, log, r.repeaterManager, eventChan, r.bridgeManager, r)
+	r.webServer = web.NewServer(cfg, log, r.repeaterManager, eventChan, r.bridgeManager, r, version, buildTime)
 
 	// Set up blocklist if configured
 	if cfg.Blocklist.Enabled && len(cfg.Blocklist.Callsigns) > 0 {

--- a/pkg/web/server.go
+++ b/pkg/web/server.go
@@ -48,6 +48,8 @@ type Server struct {
 	talkLogs        []TalkLogEntry
 	websocketHub    *WebSocketHub
 	startTime       time.Time
+	version         string
+	buildTime       string
 	mu              sync.RWMutex
 	running         bool
 	sessions        map[string]time.Time // session token -> expiry time
@@ -85,7 +87,7 @@ var upgrader = websocket.Upgrader{
 }
 
 // NewServer creates a new web server
-func NewServer(cfg *config.Config, log *logger.Logger, manager *repeater.Manager, eventChan <-chan repeater.Event, bridgeManager interface{}, reflector interface{}) *Server {
+func NewServer(cfg *config.Config, log *logger.Logger, manager *repeater.Manager, eventChan <-chan repeater.Event, bridgeManager interface{}, reflector interface{}, version, buildTime string) *Server {
 	hub := &WebSocketHub{
 		clients:    make(map[*websocket.Conn]bool),
 		broadcast:  make(chan []byte, 256),
@@ -105,6 +107,8 @@ func NewServer(cfg *config.Config, log *logger.Logger, manager *repeater.Manager
 		talkLogs:        make([]TalkLogEntry, 0),
 		websocketHub:    hub,
 		startTime:       time.Now(),
+		version:         version,
+		buildTime:       buildTime,
 		sessions:        make(map[string]time.Time),
 	}
 }
@@ -691,8 +695,8 @@ func (s *Server) handleSystemInfo(w http.ResponseWriter, r *http.Request) {
 	response := map[string]interface{}{
 		"name":           s.config.Server.Name,
 		"description":    s.config.Server.Description,
-		"version":        "dev", // This would come from build info
-		"buildTime":      "unknown",
+		"version":        s.version,
+		"buildTime":      s.buildTime,
 		"host":           s.config.Server.Host,
 		"port":           s.config.Server.Port,
 		"maxConnections": s.config.Server.MaxConnections,


### PR DESCRIPTION
## Critical Fixes and Enhancements

This PR includes **5 important improvements** to YSF Nexus:

---

## 1. Critical Bridge Deadlock Fix ⚠️

### Problem
When scheduled bridges reached their timeout duration and disconnected, the entire reflector would lock up, preventing all repeater connections and communication.

### Root Cause
The `disconnect()` function was holding the bridge mutex (`b.mu`) and calling `sendDisconnect()` → `sendPacket()`, which attempted to acquire the **same mutex again**. Since Go mutexes are not reentrant, this caused a deadlock.

### Solution
Created `sendDisconnectLocked()` that uses `sendPacketLocked()` to avoid double-locking.

---

## 2. Bridge Schedule Recovery Fix 🔄

### Problem
When restarting the server within a scheduled bridge window, the bridge would try to run for the **full configured duration** instead of just the **remaining time**, causing it to run past the intended window end time.

**Example:**
- Bridge scheduled: 9:00 PM - 10:00 PM (1 hour)  
- Server restarts: 9:30 PM (30 minutes into window)
- ❌ Old: Runs until 10:30 PM (1 hour from restart)
- ✅ New: Runs until 10:00 PM (30 minutes remaining)

### Solution
Enhanced schedule recovery to calculate remaining duration:
```go
remainingDuration = windowEnd - currentTime
```

Applied in both:
- Initial startup recovery (`setupBridge`)
- Periodic missed schedule checks (`checkMissedSchedules`)

---

## 3. Disabled Bridge Configuration Fix ⚙️

### Problem
Bridges with `enabled: false` were still being created and showing up in the dashboard/API, causing confusion.

**Example:**
- XX-ZOMBIE-ALERT with `enabled: false`
- Still appeared in dashboard as "Disconnected"
- Showed incorrect type as "Permanent"

### Solution
Added enabled check in bridge manager startup:
```go
if !bridgeConfig.Enabled {
    m.logger.Info("Skipping disabled bridge", ...)
    continue
}
```

**Result:** Disabled bridges are now completely ignored - no creation, no dashboard entry, no API response.

---

## 4. Callsign Sanitization Feature 🧹

### Problem
Callsigns with suffixes like `KF8S-DAVE`, `N8ZA/CHUCK`, or `M0FXB AND` were being forwarded as-is to other repeaters and bridges, causing display issues.

### Solution
Sanitize callsigns before forwarding by stripping everything after `-`, `/`, or space:
```
KF8S-DAVE  →  KF8S
N8ZA/CHUCK →  N8ZA  
M0FXB AND  →  M0FXB
W1ABC      →  W1ABC (unchanged)
```

### Implementation
YSF data packets (YSFD) contain three callsign fields (bytes 4-14, 14-24, 24-34). The `SanitizeDataPacket()` function:
- Creates a copy to avoid modifying original
- Sanitizes all three callsign fields
- Properly pads to 10 bytes with spaces
- Applied before broadcasting to repeaters and bridges

---

## 5. Dynamic Version Display 📊

### Problem
Dashboard footer showed hardcoded `"dev"` instead of actual build version.

### Solution
Pass version info from `main.go` through reflector to web server. Dashboard now displays actual version from git tags via ldflags.

**Example:**
```bash
make build
./bin/ysf-nexus --version
# Output: ysf-nexus version v0.3.0-5-gd6684a7 (built at 2025-09-30T15:10:00-0400)
```

Dashboard footer: `YSF Nexus v0.3.0-5-gd6684a7`

---

## Changes Made

### 1. Bridge Deadlock Fix
- `pkg/bridge/bridge.go:244` - Use `sendDisconnectLocked()`
- `pkg/bridge/bridge.go:385-389` - Add `sendDisconnectLocked()` function
- `pkg/bridge/bridge_test.go:183-223` - Add deadlock test

### 2. Schedule Recovery Fix  
- `pkg/bridge/manager.go` - Add `shouldStartNowWithDuration()` and `shouldRecoverScheduleWithDuration()`
- Calculate remaining duration: `windowEnd - currentTime`
- Apply in startup recovery and periodic checks

### 3. Disabled Bridge Fix
- `pkg/bridge/manager.go:105-108` - Check `enabled` field before setup
- `pkg/bridge/bridge_test.go` - Update test configs with `enabled: true`

### 4. Callsign Sanitization
- `pkg/network/packets.go` - Add `SanitizeCallsign()` and `SanitizeDataPacket()`
- `pkg/network/packets_sanitize_test.go` - 7 test cases
- `pkg/reflector/reflector.go` - Apply before broadcasting (3 locations)

### 5. Dynamic Version
- `pkg/web/server.go` - Add version fields, update API
- `pkg/reflector/reflector.go` - Add `NewWithVersion()`
- `cmd/ysf-nexus/main.go` - Pass version to reflector

---

## Testing

✅ **Bridge deadlock test** - Reproduces bug (fails before, passes after)  
✅ **Schedule recovery** - Test logs show correct remaining duration (`1.821s` from `2s` window)  
✅ **Disabled bridges** - Not created, not in API/dashboard
✅ **Callsign sanitization** - 7 test cases covering edge cases  
✅ **All existing tests pass** - bridge, network, repeater, config  
✅ **Successful build** - No warnings

---

## Impact

- **Critical**: Prevents reflector lockup on bridge disconnections
- **Important**: Bridges respect scheduled window boundaries on restart
- **Important**: Disabled bridges are properly ignored
- **Enhancement**: Clean callsign display for all users  
- **Enhancement**: Easy version tracking in production

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)